### PR TITLE
fix: derive prequantized-primary from quant label, not filename (#21)

### DIFF
--- a/builds/release.yaml
+++ b/builds/release.yaml
@@ -16,6 +16,9 @@ build:
 
 targets:
   - id: jinaai/jina-embeddings-v5-text-nano-retrieval
+    # quant: output scheme; also selects the tarball filename. build_target.sh
+    # runs pipeline int8 quantization ONLY for int8|q8; every other label
+    # (q4f16 here) is treated as pre-quantized from HF and skips that step.
     quant: q4f16
     bundle_extras:
       - tokenizer.json

--- a/scripts/build_target.sh
+++ b/scripts/build_target.sh
@@ -93,10 +93,29 @@ if [ -n "${HF_COMPANIONS}" ]; then
     done
 fi
 
-PREQUANTIZED_PRIMARY=0
-if [ "$(basename "${HF_PRIMARY}")" = "model_q4f16.onnx" ]; then
-    PREQUANTIZED_PRIMARY=1
-fi
+# ---------------------------------------------------------------------------
+# 5b. Decide whether to run int8 dynamic quantization (optimize step 4)
+#
+# The build pipeline can only ever *produce* int8 dynamic quantization itself
+# (optimize_model.py step 4 = QuantType.QInt8). Every other quantization scheme
+# (e.g. q4f16) must arrive already-quantized from Hugging Face, so running step 4
+# on it would corrupt an already-quantized graph. We therefore run step 4 only
+# for the opt-in set of quant labels that name pipeline-produced int8; anything
+# else is treated as pre-quantized and skips it. Safe by default: an unrecognised
+# (future) pre-quantized scheme skips int8 rather than being re-quantized.
+# See issue #21. QUANT is validated lowercase, so no case-folding is needed.
+#
+# CAVEAT: the quant label names the *output* scheme (it feeds the tarball
+# filename), whereas int8|q8 here means "the pipeline should *produce* int8".
+# These only collide if a target ships an *already*-quantized q8 model from HF:
+# labelling it quant: q8 would re-quantize it. No such target exists today; if
+# one is added, label it with a non-q8 scheme (or revisit this case) so it is
+# treated as pre-quantized.
+# ---------------------------------------------------------------------------
+PREQUANTIZED_PRIMARY=1
+case "${QUANT}" in
+    int8|q8) PREQUANTIZED_PRIMARY=0 ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 6. Clone ORT source

--- a/tests/test_ci_contracts.py
+++ b/tests/test_ci_contracts.py
@@ -126,11 +126,17 @@ def test_release_manifest_uses_published_quantized_onnx_for_jina_nano() -> None:
     assert "- onnx/model_q4f16.onnx_data" in text
 
 
-def test_build_script_skips_only_step4_for_prequantized_primary() -> None:
-    """Pre-quantized ONNX inputs should still run optimize_model.py and only skip step 4."""
+def test_build_script_derives_int8_skip_from_quant() -> None:
+    """Pre-quantized detection must be quant-driven, not a hardcoded filename, and
+    still run optimize_model.py while only skipping step 4."""
     text = BUILD_SCRIPT.read_text(encoding="utf-8")
-    assert 'PREQUANTIZED_PRIMARY=0' in text
-    assert 'basename "${HF_PRIMARY}"' in text
+    # The old filename heuristic is gone: this literal only ever appeared in that
+    # check (the manifest reference lives in release.yaml, not this script).
+    assert '"model_q4f16.onnx"' not in text
+    # Quant-driven derivation, safe-by-default (prequantized unless opted in).
+    assert 'PREQUANTIZED_PRIMARY=1' in text
+    assert 'case "${QUANT}"' in text
+    assert 'int8|q8)' in text
     assert 'Using pre-quantized ONNX model directly' not in text
     assert '--skip-int8-quantize' in text
     assert 'python3 "$(dirname "$0")/optimize_model.py"' in text


### PR DESCRIPTION
## Summary
`scripts/build_target.sh` detected a pre-quantized primary by an exact filename match on `model_q4f16.onnx`. Any future pre-quantized model with a different name (the issue's `model_q8.onnx` example) would be misclassified and re-quantized — running int8 dynamic quantization (`optimize_model.py` step 4) on an already-quantized graph.

This replaces the filename heuristic with a **manifest-driven** decision: the primary's provenance is derived from the `quant` label (populated from the manifest via `emit_matrix.py` → `QUANT`). Only `int8|q8` opt in to pipeline-produced int8; everything else — including the current `q4f16` target — is treated as pre-quantized and passes `--skip-int8-quantize`. **Safe by default:** an unrecognised future scheme skips int8 rather than being re-quantized.

A caveat comment documents the one edge where the label collides: an *already*-quantized q8 model from HF labelled `quant: q8` would be re-quantized. No such target exists today; if one is added, label it with a non-`q8` scheme.

## Changes
- `scripts/build_target.sh` — step 5b now derives `PREQUANTIZED_PRIMARY` from `QUANT` via a `case`, with the caveat comment.
- `tests/test_ci_contracts.py` — `test_build_script_derives_int8_skip_from_quant` asserts the filename literal is gone and the quant-driven derivation is present.

## Verification
- `pytest tests/test_ci_contracts.py` → 21 passed; full collectable suite → 76 passed (`test_gen_reference_vectors.py` skipped: unrelated local numpy-not-installed).
- `grep '"model_q4f16.onnx"' scripts/build_target.sh` → no match.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)