### PR TITLE
feat: benchmark workflow to compare model/quant performance (#23)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,181 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      source:
+        description: "build (fresh from manifest) or release (download assets)"
+        type: choice
+        options:
+          - build
+          - release
+        default: build
+      release_tag:
+        description: "Release tag to download (required when source=release)"
+        type: string
+        default: ""
+      warmup:
+        description: "Untimed warmup iterations"
+        type: string
+        default: "10"
+      iters:
+        description: "Timed iterations"
+        type: string
+        default: "100"
+      num_samples:
+        description: "Fixture texts to cycle"
+        type: string
+        default: "3"
+      max_tokens:
+        description: "Token truncation length"
+        type: string
+        default: "128"
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.emit.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install tooling deps
+        run: pip install pyyaml pytest numpy
+
+      - name: Validate manifest
+        run: python scripts/validate_manifest.py builds/release.yaml
+
+      - name: Run regression tests
+        run: pytest tests/test_validate_manifest.py tests/test_optimize_model.py tests/test_ci_contracts.py tests/test_gen_reference_vectors.py -q
+
+      - name: Emit matrix
+        id: emit
+        run: |
+          MATRIX=$(python scripts/emit_matrix.py builds/release.yaml)
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
+  benchmark:
+    needs: plan
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download release tarball
+        if: ${{ inputs.source == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          ASSET: ${{ matrix.target.target_id_safe }}_${{ matrix.target.quant }}_linux-arm64.tar.gz
+        run: |
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "release_tag input is required when source=release" >&2
+            exit 1
+          fi
+          mkdir -p release
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "${ASSET}" \
+            --dir release
+
+      - name: Build Docker image
+        run: docker build -t ort-build:local -f docker/lambda-build.Dockerfile docker/
+
+      - name: Benchmark target in Lambda container
+        env:
+          TARGET_ID: ${{ matrix.target.target_id }}
+          ORT_VERSION: ${{ matrix.target.ort_version }}
+          QUANT: ${{ matrix.target.quant }}
+          HF_REPO_ID: ${{ matrix.target.hf_repo_id }}
+          HF_REVISION: ${{ matrix.target.hf_revision }}
+          HF_PRIMARY: ${{ matrix.target.hf_primary }}
+          HF_COMPANIONS: ${{ matrix.target.hf_companions }}
+          BUNDLE_EXTRAS: ${{ matrix.target.bundle_extras }}
+          MODEL_METADATA: ${{ matrix.target.model_metadata }}
+          CPU_TUNING: ${{ matrix.target.cpu_tuning }}
+          EXECUTION_PROVIDER: ${{ matrix.target.execution_provider }}
+          MINIMAL_BUILD: ${{ matrix.target.minimal_build }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          SOURCE: ${{ inputs.source }}
+          WARMUP: ${{ inputs.warmup }}
+          ITERS: ${{ inputs.iters }}
+          NUM_SAMPLES: ${{ inputs.num_samples }}
+          MAX_TOKENS: ${{ inputs.max_tokens }}
+        run: |
+          mkdir -p output release
+          docker run --rm \
+            -v "$(pwd)/scripts:/scripts:ro" \
+            -v "$(pwd)/builds:/manifest:ro" \
+            -v "$(pwd)/tests/data:/fixtures:ro" \
+            -v "$(pwd)/output:/output" \
+            -v "$(pwd)/release:/release:ro" \
+            -e TARGET_ID \
+            -e ORT_VERSION \
+            -e QUANT \
+            -e HF_REPO_ID \
+            -e HF_REVISION \
+            -e HF_PRIMARY \
+            -e HF_COMPANIONS \
+            -e BUNDLE_EXTRAS \
+            -e MODEL_METADATA \
+            -e CPU_TUNING \
+            -e EXECUTION_PROVIDER \
+            -e MINIMAL_BUILD \
+            -e HF_TOKEN \
+            -e SOURCE \
+            -e WARMUP \
+            -e ITERS \
+            -e NUM_SAMPLES \
+            -e MAX_TOKENS \
+            -e FIXTURE_DIR=/fixtures \
+            -e OUTPUT_DIR=/output \
+            -e RELEASE_DIR=/release \
+            -e PYTHONUNBUFFERED=1 \
+            ort-build:local \
+            /scripts/run_benchmark.py
+
+      - name: Upload bench result
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-${{ matrix.target.target_id_safe }}_${{ matrix.target.quant }}
+          path: output/bench-*.json
+          if-no-files-found: error
+          retention-days: 1
+
+  report:
+    needs: benchmark
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Download all bench results
+        uses: actions/download-artifact@v7
+        with:
+          path: bench-results
+          merge-multiple: true
+
+      - name: Render report
+        run: python scripts/render_benchmark_report.py bench-results .
+
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-report
+          path: |
+            results.json
+            report.md
+          if-no-files-found: error

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -112,6 +112,7 @@ jobs:
         run: |
           mkdir -p output release
           docker run --rm \
+            --entrypoint python3 \
             -v "$(pwd)/scripts:/scripts:ro" \
             -v "$(pwd)/builds:/manifest:ro" \
             -v "$(pwd)/tests/data:/fixtures:ro" \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ build:
     - build-info.json
 
 targets:
-  - id: phi3-mini-q4f16     # unique slug; used in artifact names
+  - id: phi3-mini-q4f16     # model slug; unique per (id, quant), used in artifact names
     quant: q4f16            # quantisation identifier; included in the tarball filename
     model:
       repo_id: microsoft/Phi-3-mini-4k-instruct-onnx   # Hugging Face repo in "owner/repo" format
@@ -53,7 +53,10 @@ targets:
         - tokenizer.json
 ```
 
-To add a second target, append another entry under `targets` with a distinct `id`.
+To add a second target, append another entry under `targets`. Each `(id, quant)`
+pair must be unique, so the same model `id` may appear more than once with
+different `quant` values (e.g. to compare quantisation schemes) — each produces
+its own tarball named `<id_safe>_<quant>_linux-arm64.tar.gz`.
 
 ---
 
@@ -87,7 +90,7 @@ The following rules are enforced by `scripts/validate_manifest.py`:
 | 5 | `targets` must be a non-empty list |
 | 6 | Each target must have `id`, `quant`, and `model` |
 | 6b | `quant` must match `^[a-z0-9][a-z0-9\-]*$` (e.g. `fp32`, `q4f16`, `int8`) |
-| 7 | Target `id` values must be unique across all targets |
+| 7 | Each `(id, quant)` pair must be unique across all targets (the same `id` may repeat with different `quant` values) |
 | 8 | Targets must not contain a per-target `onnxruntime` key (the global one is used) |
 | 9 | Each `model` must have `repo_id`, `revision`, `primary`, and `companions` |
 | 9b | `companions` must be a list (not a string or other scalar) |

--- a/builds/release.yaml
+++ b/builds/release.yaml
@@ -40,3 +40,54 @@ targets:
       companions:
         - onnx/model_q4f16.onnx_data
         - tokenizer.json
+
+  # Additional quants of the same model. The manifest keys uniqueness on
+  # (id, quant), so these share the id above and differ only in quant/primary.
+  # All are pre-quantized from HF (non-int8/q8 labels), so none trigger the
+  # pipeline int8 step. Primarily consumed by the benchmark workflow to compare
+  # quantization schemes side by side.
+  - id: jinaai/jina-embeddings-v5-text-nano-retrieval
+    quant: fp16
+    bundle_extras:
+      - tokenizer.json
+      - build-info.json
+    metadata:
+      model_format: ort
+      model_type: bert
+      pooling: last_token
+      input_kind: retrieval
+      query_prefix: "Query: "
+      document_prefix: "Document: "
+      raw_embedding_dimension: 768
+      output_embedding_dimension: 768
+      max_length: 8192
+    model:
+      repo_id: jinaai/jina-embeddings-v5-text-nano-retrieval
+      revision: main
+      primary: onnx/model_fp16.onnx
+      companions:
+        - onnx/model_fp16.onnx_data
+        - tokenizer.json
+
+  - id: jinaai/jina-embeddings-v5-text-nano-retrieval
+    quant: q4
+    bundle_extras:
+      - tokenizer.json
+      - build-info.json
+    metadata:
+      model_format: ort
+      model_type: bert
+      pooling: last_token
+      input_kind: retrieval
+      query_prefix: "Query: "
+      document_prefix: "Document: "
+      raw_embedding_dimension: 768
+      output_embedding_dimension: 768
+      max_length: 8192
+    model:
+      repo_id: jinaai/jina-embeddings-v5-text-nano-retrieval
+      revision: main
+      primary: onnx/model_q4.onnx
+      companions:
+        - onnx/model_q4.onnx_data
+        - tokenizer.json

--- a/scripts/bench.c
+++ b/scripts/bench.c
@@ -1,0 +1,289 @@
+/*
+ * bench.c — minimal ORT inference benchmark harness.
+ *
+ *   ./bench <model.ort> <vectors.tvbin> <warmup> <iters>
+ *       Load the model, replay the tokenized inputs from the test-vectors file
+ *       in a timed loop, and emit latency/throughput/memory/size metrics as a
+ *       single JSON object on stdout.
+ *
+ * Reuses the TVB1 reader and session setup from smoke_test.c. The reference
+ * payload in the .tvbin is read and ignored — this harness times Run(), it does
+ * not check correctness (that is the smoke test's job). Vectors produced by
+ * `gen_reference_vectors.py --inputs-only` carry an empty reference payload.
+ *
+ * Runtime graph optimization is disabled (ORT_DISABLE_ALL) to match the smoke
+ * test and what ships: the model is already fully optimized offline. Inference
+ * is single-threaded, batch=1 (SetIntraOpNumThreads(1)/SetInterOpNumThreads(1))
+ * to model a serverless/Lambda profile.
+ */
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/resource.h>
+#include "onnxruntime_c_api.h"
+
+#define ORT_CHECK(expr, label)                                              \
+    do {                                                                    \
+        OrtStatus *_s = (expr);                                             \
+        if (_s) {                                                           \
+            fprintf(stderr, "BENCH FAIL: %s: %s\n",                         \
+                    (label), api->GetErrorMessage(_s));                     \
+            api->ReleaseStatus(_s);                                         \
+            goto cleanup;                                                   \
+        }                                                                   \
+    } while (0)
+
+static ONNXTensorElementDataType code_to_ort(uint32_t code) {
+    switch (code) {
+        case 0: return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+        case 1: return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT16;
+        case 2: return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64;
+        case 3: return ONNX_TENSOR_ELEMENT_DATA_TYPE_INT32;
+        default:
+            fprintf(stderr,
+                    "BENCH WARN: unknown .tvbin dtype code %u; assuming float32\n",
+                    code);
+            return ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT;
+    }
+}
+
+static int read_exact(FILE *f, void *dst, size_t n) {
+    return fread(dst, 1, n, f) == n;
+}
+
+static double now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec * 1000.0 + (double)ts.tv_nsec / 1.0e6;
+}
+
+static int cmp_double(const void *a, const void *b) {
+    double da = *(const double *)a, db = *(const double *)b;
+    return (da > db) - (da < db);
+}
+
+/* Nearest-rank percentile over a sorted ascending array. */
+static double percentile(const double *sorted, size_t n, double frac) {
+    if (n == 0) return 0.0;
+    double pos = frac * (double)(n - 1) + 0.5;
+    size_t idx = (size_t)pos;
+    if (idx >= n) idx = n - 1;
+    return sorted[idx];
+}
+
+/* One decoded sample: named input tensors ready to feed to Run(). */
+typedef struct {
+    uint32_t num_inputs;
+    char **names;
+    OrtValue **tensors;
+    void **bufs;
+} Sample;
+
+int main(int argc, char *argv[]) {
+    if (argc != 5) {
+        fprintf(stderr, "Usage: %s <model.ort> <vectors.tvbin> <warmup> <iters>\n",
+                argv[0]);
+        return 1;
+    }
+    const char *model_path = argv[1];
+    const char *tvpath = argv[2];
+    long warmup = atol(argv[3]);
+    long iters = atol(argv[4]);
+    if (iters <= 0) {
+        fprintf(stderr, "BENCH FAIL: iters must be > 0\n");
+        return 1;
+    }
+    if (warmup < 0) warmup = 0;
+
+    int exit_code = 1;
+    const OrtApiBase *base = OrtGetApiBase();
+    if (!base) {
+        fprintf(stderr, "BENCH FAIL: OrtGetApiBase() returned NULL\n");
+        return 1;
+    }
+    const OrtApi *api = base->GetApi(ORT_API_VERSION);
+    if (!api) {
+        fprintf(stderr, "BENCH FAIL: could not get ORT API\n");
+        return 1;
+    }
+
+    OrtEnv *env = NULL;
+    OrtSessionOptions *opts = NULL;
+    OrtSession *session = NULL;
+    OrtMemoryInfo *mem_info = NULL;
+    OrtAllocator *allocator = NULL;
+    char *out_name = NULL;
+    Sample *samples = NULL;
+    uint32_t num_samples = 0;
+    double *times = NULL;
+    FILE *f = NULL;
+
+    ORT_CHECK(api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "bench", &env), "CreateEnv");
+    ORT_CHECK(api->CreateSessionOptions(&opts), "CreateSessionOptions");
+    ORT_CHECK(api->SetSessionGraphOptimizationLevel(opts, ORT_DISABLE_ALL),
+              "SetSessionGraphOptimizationLevel");
+    ORT_CHECK(api->SetIntraOpNumThreads(opts, 1), "SetIntraOpNumThreads");
+    ORT_CHECK(api->SetInterOpNumThreads(opts, 1), "SetInterOpNumThreads");
+
+    double load_start = now_ms();
+    ORT_CHECK(api->CreateSession(env, model_path, opts, &session), "CreateSession");
+    double load_ms = now_ms() - load_start;
+
+    ORT_CHECK(api->CreateCpuMemoryInfo(OrtArenaAllocator, OrtMemTypeDefault, &mem_info),
+              "CreateCpuMemoryInfo");
+    ORT_CHECK(api->GetAllocatorWithDefaultOptions(&allocator),
+              "GetAllocatorWithDefaultOptions");
+    ORT_CHECK(api->SessionGetOutputName(session, 0, allocator, &out_name),
+              "SessionGetOutputName");
+
+    /* Load all samples into memory (tensors persist across iterations). */
+    f = fopen(tvpath, "rb");
+    if (!f) {
+        fprintf(stderr, "BENCH FAIL: cannot open %s\n", tvpath);
+        goto cleanup;
+    }
+    char magic[4];
+    if (!read_exact(f, magic, 4) || memcmp(magic, "TVB1", 4) != 0 ||
+        !read_exact(f, &num_samples, 4)) {
+        fprintf(stderr, "BENCH FAIL: bad or truncated test-vectors header\n");
+        goto cleanup;
+    }
+    if (num_samples == 0) {
+        fprintf(stderr, "BENCH FAIL: test-vectors file has no samples\n");
+        goto cleanup;
+    }
+    samples = calloc(num_samples, sizeof(Sample));
+    if (!samples) { fprintf(stderr, "BENCH FAIL: out of memory\n"); goto cleanup; }
+
+    for (uint32_t si = 0; si < num_samples; si++) {
+        uint32_t num_inputs = 0;
+        if (!read_exact(f, &num_inputs, 4)) {
+            fprintf(stderr, "BENCH FAIL: truncated sample %u\n", si);
+            goto cleanup;
+        }
+        Sample *s = &samples[si];
+        s->num_inputs = num_inputs;
+        s->names = calloc(num_inputs, sizeof(char *));
+        s->tensors = calloc(num_inputs, sizeof(OrtValue *));
+        s->bufs = calloc(num_inputs, sizeof(void *));
+        if (!s->names || !s->tensors || !s->bufs) {
+            fprintf(stderr, "BENCH FAIL: out of memory\n");
+            goto cleanup;
+        }
+        for (uint32_t ii = 0; ii < num_inputs; ii++) {
+            uint32_t name_len = 0, dcode = 0, ndim = 0;
+            if (!read_exact(f, &name_len, 4)) { goto trunc; }
+            s->names[ii] = malloc((size_t)name_len + 1);
+            if (!s->names[ii] || !read_exact(f, s->names[ii], name_len)) { goto trunc; }
+            s->names[ii][name_len] = '\0';
+            if (!read_exact(f, &dcode, 4) || !read_exact(f, &ndim, 4)) { goto trunc; }
+            int64_t *dims = calloc(ndim ? ndim : 1, sizeof(int64_t));
+            if (!dims) { fprintf(stderr, "BENCH FAIL: out of memory\n"); goto cleanup; }
+            for (uint32_t d = 0; d < ndim; d++) {
+                if (!read_exact(f, &dims[d], 8)) { free(dims); goto trunc; }
+            }
+            uint64_t nbytes = 0;
+            if (!read_exact(f, &nbytes, 8)) { free(dims); goto trunc; }
+            s->bufs[ii] = malloc(nbytes ? nbytes : 1);
+            if (!s->bufs[ii] || !read_exact(f, s->bufs[ii], nbytes)) { free(dims); goto trunc; }
+            OrtStatus *ts = api->CreateTensorWithDataAsOrtValue(
+                mem_info, s->bufs[ii], nbytes, dims, ndim, code_to_ort(dcode),
+                &s->tensors[ii]);
+            free(dims);
+            if (ts) {
+                fprintf(stderr, "BENCH FAIL: CreateTensor: %s\n", api->GetErrorMessage(ts));
+                api->ReleaseStatus(ts);
+                goto cleanup;
+            }
+        }
+        /* Reference payload: read the count and skip the floats (ignored). */
+        uint64_t ref_count = 0;
+        if (!read_exact(f, &ref_count, 8)) { goto trunc; }
+        if (ref_count && fseek(f, (long)(ref_count * sizeof(float)), SEEK_CUR) != 0) {
+            goto trunc;
+        }
+        continue;
+    trunc:
+        fprintf(stderr, "BENCH FAIL: truncated sample %u\n", si);
+        goto cleanup;
+    }
+    fclose(f);
+    f = NULL;
+
+    /* Warmup (untimed), then timed loop, cycling samples. */
+    for (long i = 0; i < warmup; i++) {
+        Sample *s = &samples[i % num_samples];
+        OrtValue *output = NULL;
+        ORT_CHECK(api->Run(session, NULL,
+                           (const char *const *)s->names,
+                           (const OrtValue *const *)s->tensors, s->num_inputs,
+                           (const char *const *)&out_name, 1, &output), "Run(warmup)");
+        api->ReleaseValue(output);
+    }
+
+    times = malloc((size_t)iters * sizeof(double));
+    if (!times) { fprintf(stderr, "BENCH FAIL: out of memory\n"); goto cleanup; }
+    for (long i = 0; i < iters; i++) {
+        Sample *s = &samples[i % num_samples];
+        OrtValue *output = NULL;
+        double t0 = now_ms();
+        ORT_CHECK(api->Run(session, NULL,
+                           (const char *const *)s->names,
+                           (const OrtValue *const *)s->tensors, s->num_inputs,
+                           (const char *const *)&out_name, 1, &output), "Run");
+        double t1 = now_ms();
+        api->ReleaseValue(output);
+        times[i] = t1 - t0;
+    }
+
+    double sum = 0.0;
+    for (long i = 0; i < iters; i++) sum += times[i];
+    double mean_ms = sum / (double)iters;
+    qsort(times, (size_t)iters, sizeof(double), cmp_double);
+    double p50 = percentile(times, (size_t)iters, 0.50);
+    double p90 = percentile(times, (size_t)iters, 0.90);
+    double p99 = percentile(times, (size_t)iters, 0.99);
+    double throughput_ips = mean_ms > 0.0 ? 1000.0 / mean_ms : 0.0;
+
+    struct rusage ru;
+    long peak_rss_kb = 0;
+    if (getrusage(RUSAGE_SELF, &ru) == 0) peak_rss_kb = ru.ru_maxrss;
+
+    printf("{\"load_ms\": %.3f, \"iters\": %ld, \"mean_ms\": %.4f, "
+           "\"p50_ms\": %.4f, \"p90_ms\": %.4f, \"p99_ms\": %.4f, "
+           "\"throughput_ips\": %.2f, \"peak_rss_kb\": %ld}\n",
+           load_ms, iters, mean_ms, p50, p90, p99, throughput_ips, peak_rss_kb);
+    exit_code = 0;
+
+cleanup:
+    if (f) fclose(f);
+    free(times);
+    if (samples) {
+        for (uint32_t si = 0; si < num_samples; si++) {
+            Sample *s = &samples[si];
+            if (s->tensors) {
+                for (uint32_t ii = 0; ii < s->num_inputs; ii++)
+                    if (s->tensors[ii]) api->ReleaseValue(s->tensors[ii]);
+                free(s->tensors);
+            }
+            if (s->bufs) {
+                for (uint32_t ii = 0; ii < s->num_inputs; ii++) free(s->bufs[ii]);
+                free(s->bufs);
+            }
+            if (s->names) {
+                for (uint32_t ii = 0; ii < s->num_inputs; ii++) free(s->names[ii]);
+                free(s->names);
+            }
+        }
+        free(samples);
+    }
+    if (out_name) api->AllocatorFree(allocator, out_name);
+    if (mem_info) api->ReleaseMemoryInfo(mem_info);
+    if (session)  api->ReleaseSession(session);
+    if (opts)     api->ReleaseSessionOptions(opts);
+    if (env)      api->ReleaseEnv(env);
+    return exit_code;
+}

--- a/scripts/gen_reference_vectors.py
+++ b/scripts/gen_reference_vectors.py
@@ -133,12 +133,23 @@ def main(argv=None):
     parser.add_argument("--output", required=True, help="Output .tvbin path")
     parser.add_argument("--num-samples", type=int, default=3)
     parser.add_argument("--max-tokens", type=int, default=128)
+    parser.add_argument(
+        "--inputs-only",
+        action="store_true",
+        help="Emit token feeds with an empty reference payload (ref_count=0); "
+        "skips reference output computation. Used by the benchmark harness, "
+        "which times Run() and ignores the reference.",
+    )
     args = parser.parse_args(argv)
 
     import onnxruntime as ort
     from tokenizers import Tokenizer
 
     tokenizer = Tokenizer.from_file(args.tokenizer)
+    # The session is still needed to learn which inputs the model declares so
+    # build_feeds produces exactly those; only the reference Run() is skipped
+    # under --inputs-only. The model may be a .ort artifact, which onnxruntime
+    # loads the same as .onnx.
     session = ort.InferenceSession(args.model, providers=["CPUExecutionProvider"])
     input_names = [i.name for i in session.get_inputs()]
     output_name = session.get_outputs()[0].name
@@ -148,12 +159,16 @@ def main(argv=None):
     for text in texts:
         ids = truncate_ids(tokenizer.encode(text).ids, args.max_tokens)
         feeds = build_feeds(input_names, ids)
-        output = session.run([output_name], feeds)[0]
-        reference = np.asarray(output, dtype=np.float32).reshape(-1)
+        if args.inputs_only:
+            reference = np.empty(0, dtype=np.float32)
+        else:
+            output = session.run([output_name], feeds)[0]
+            reference = np.asarray(output, dtype=np.float32).reshape(-1)
         samples.append({"inputs": feeds, "reference": reference})
 
     write_vectors(args.output, samples)
-    print(f"    wrote {len(samples)} reference sample(s) to {args.output}")
+    kind = "input-only" if args.inputs_only else "reference"
+    print(f"    wrote {len(samples)} {kind} sample(s) to {args.output}")
 
 
 if __name__ == "__main__":

--- a/scripts/render_benchmark_report.py
+++ b/scripts/render_benchmark_report.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""render_benchmark_report.py — aggregate per-target bench JSON into a report.
+
+    render_benchmark_report.py <input_dir> [output_dir]
+
+Globs `bench-*.json` from <input_dir>, renders a side-by-side Markdown comparison
+table (one row per target/quant), and writes:
+
+    <output_dir>/report.md      the Markdown table
+    <output_dir>/results.json   the combined list of all target results
+
+If $GITHUB_STEP_SUMMARY is set, the table is also appended there so it renders in
+the Actions run UI. <output_dir> defaults to the current directory.
+"""
+
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+
+# (json_key, column header) in issue-specified order.
+COLUMNS = [
+    ("target_id", "target_id"),
+    ("quant", "quant"),
+    ("load_ms", "load_ms"),
+    ("mean_ms", "mean_ms"),
+    ("p50_ms", "p50_ms"),
+    ("p90_ms", "p90_ms"),
+    ("p99_ms", "p99_ms"),
+    ("throughput_ips", "throughput_ips"),
+    ("peak_rss_kb", "peak_rss_kb"),
+    ("so_bytes", "so_bytes"),
+    ("model_ort_bytes", "model_ort_bytes"),
+    ("tarball_bytes", "tarball_bytes"),
+    ("ort_version", "ort_version"),
+]
+
+
+def _fmt(key, value):
+    if value is None:
+        return ""
+    if key.endswith("_ms"):
+        return f"{float(value):.3f}"
+    if key == "throughput_ips":
+        return f"{float(value):.2f}"
+    if key.endswith("_bytes") or key.endswith("_kb"):
+        return f"{int(value):,}"
+    return str(value)
+
+
+def render_table(results):
+    headers = [header for _, header in COLUMNS]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in results:
+        cells = [_fmt(key, row.get(key)) for key, _ in COLUMNS]
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    argv = argv if argv is not None else sys.argv[1:]
+    if not argv:
+        sys.exit("Usage: render_benchmark_report.py <input_dir> [output_dir]")
+    input_dir = Path(argv[0])
+    output_dir = Path(argv[1]) if len(argv) > 1 else Path(".")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for path in sorted(glob.glob(str(input_dir / "bench-*.json"))):
+        with open(path, "r", encoding="utf-8") as fh:
+            results.append(json.load(fh))
+    results.sort(key=lambda r: (r.get("target_id", ""), r.get("quant", "")))
+
+    table = render_table(results)
+    report = "# Benchmark comparison\n\n" + table
+
+    (output_dir / "report.md").write_text(report, encoding="utf-8")
+    (output_dir / "results.json").write_text(
+        json.dumps(results, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(report)
+
+    print(f"rendered {len(results)} result(s) to {output_dir / 'report.md'}")
+    sys.stdout.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""run_benchmark.py — per-target inference benchmark orchestrator.
+
+Runs inside the lambda-build (AL2023) container, one invocation per matrix
+target. Obtains a shipped tarball (either by building it fresh from the manifest
+entry, or from a release asset the workflow pre-downloaded on the runner),
+compiles `bench.c` against the extracted `libonnxruntime.so`, replays token feeds
+through the shipped `model.ort`, and writes a merged metrics JSON:
+
+    bench-<id_safe>_<quant>.json
+
+Configuration is supplied via environment variables (same contract as
+build_target.sh), plus:
+
+    SOURCE       "build" (run build_target.sh) or "release" (use pre-downloaded)
+    RELEASE_DIR  where the release tarball was mounted (default /release)
+    WARMUP       untimed warmup iterations (default 10)
+    ITERS        timed iterations (default 100)
+    NUM_SAMPLES  fixture texts to cycle (default 3)
+    MAX_TOKENS   token truncation length (default 128)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+ORT_REPO = "https://github.com/microsoft/onnxruntime.git"
+FIXTURE_NAME = "jane-austen_pride-and-prejudice.jsonl"
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+def _env(name, default=None, required=False):
+    val = os.environ.get(name, default)
+    if required and not val:
+        sys.exit(f"run_benchmark: {name} is required")
+    return val
+
+
+def _run(cmd, **kwargs):
+    printable = " ".join(str(c) for c in cmd)
+    print(f"==> {printable}", flush=True)
+    return subprocess.run(cmd, check=True, **kwargs)
+
+
+def _id_safe(target_id):
+    return target_id.replace("/", "__")
+
+
+def build_tarball(output_dir):
+    """SOURCE=build: run build_target.sh from the inherited env."""
+    print("==> Building target from manifest entry", flush=True)
+    _run([str(SCRIPTS_DIR / "build_target.sh")])
+    return None  # tarball located by caller from OUTPUT_DIR
+
+
+def sparse_clone_headers(ort_version, dest):
+    """Sparse-checkout just the ORT C API header dir at the given tag."""
+    _run([
+        "git", "clone", "--depth", "1", "--branch", ort_version,
+        "--filter=blob:none", "--sparse", ORT_REPO, str(dest),
+    ])
+    _run([
+        "git", "-C", str(dest), "sparse-checkout", "set",
+        "include/onnxruntime/core/session",
+    ])
+    include_dir = dest / "include" / "onnxruntime" / "core" / "session"
+    if not (include_dir / "onnxruntime_c_api.h").is_file():
+        sys.exit(f"run_benchmark: onnxruntime_c_api.h not found under {include_dir}")
+    return include_dir
+
+
+def main():
+    source = _env("SOURCE", "build")
+    target_id = _env("TARGET_ID", required=True)
+    quant = _env("QUANT", required=True)
+    id_safe = _id_safe(target_id)
+    output_dir = Path(_env("OUTPUT_DIR", "/output"))
+    fixture_dir = Path(_env("FIXTURE_DIR", "/fixtures"))
+    warmup = _env("WARMUP", "10")
+    iters = _env("ITERS", "100")
+    num_samples = _env("NUM_SAMPLES", "3")
+    max_tokens = _env("MAX_TOKENS", "128")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tarball_name = f"{id_safe}_{quant}_linux-arm64.tar.gz"
+
+    if source == "build":
+        build_tarball(output_dir)
+        tarball = output_dir / tarball_name
+    elif source == "release":
+        release_dir = Path(_env("RELEASE_DIR", "/release"))
+        tarball = release_dir / tarball_name
+    else:
+        sys.exit(f"run_benchmark: SOURCE must be 'build' or 'release', got {source!r}")
+
+    if not tarball.is_file():
+        sys.exit(f"run_benchmark: tarball not found: {tarball}")
+    tarball_bytes = tarball.stat().st_size
+
+    work = Path(tempfile.mkdtemp(prefix="bench-"))
+    extract_dir = work / "artifact"
+    extract_dir.mkdir()
+    print(f"==> Extracting {tarball}", flush=True)
+    with tarfile.open(tarball, "r:gz") as tf:
+        tf.extractall(extract_dir)
+
+    so_path = extract_dir / "libonnxruntime.so"
+    model_path = extract_dir / "model.ort"
+    tokenizer_path = extract_dir / "tokenizer.json"
+    build_info_path = extract_dir / "build-info.json"
+    for required in (so_path, model_path, tokenizer_path, build_info_path):
+        if not required.is_file():
+            sys.exit(f"run_benchmark: missing {required.name} in tarball")
+
+    build_info = json.loads(build_info_path.read_text(encoding="utf-8"))
+    ort_version = build_info.get("ort_version") or _env("ORT_VERSION", required=True)
+    ort_git_sha = build_info.get("ort_git_sha", "")
+
+    include_dir = sparse_clone_headers(ort_version, work / "ort-headers")
+
+    # Token feeds only; the harness times Run() and ignores the reference.
+    tvbin = work / "bench.tvbin"
+    _run([
+        sys.executable, str(SCRIPTS_DIR / "gen_reference_vectors.py"),
+        "--inputs-only",
+        "--model", str(model_path),
+        "--tokenizer", str(tokenizer_path),
+        "--fixture", str(fixture_dir / FIXTURE_NAME),
+        "--output", str(tvbin),
+        "--num-samples", num_samples,
+        "--max-tokens", max_tokens,
+    ])
+
+    bench_bin = work / "bench"
+    _run([
+        "clang", "-O2", "-o", str(bench_bin), str(SCRIPTS_DIR / "bench.c"),
+        "-I", str(include_dir),
+        "-L", str(extract_dir),
+        "-lonnxruntime",
+        "-lm",
+        "-Wl,-rpath," + str(extract_dir),
+    ])
+
+    proc = _run(
+        [str(bench_bin), str(model_path), str(tvbin), warmup, iters],
+        capture_output=True, text=True,
+    )
+    sys.stderr.write(proc.stderr)
+    metrics = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    result = {
+        "target_id": target_id,
+        "quant": quant,
+        "ort_version": ort_version,
+        "ort_git_sha": ort_git_sha,
+        **metrics,
+        "so_bytes": so_path.stat().st_size,
+        "model_ort_bytes": model_path.stat().st_size,
+        "tarball_bytes": tarball_bytes,
+    }
+
+    out_file = output_dir / f"bench-{id_safe}_{quant}.json"
+    out_file.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"==> wrote {out_file}", flush=True)
+    print(json.dumps(result, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -74,7 +74,7 @@ def validate(data: dict) -> None:
     if not isinstance(targets, list) or len(targets) == 0:
         _fail("'targets' must be a non-empty list")
 
-    seen_ids: set[str] = set()
+    seen_id_quants: set[tuple] = set()
 
     for i, target in enumerate(targets):
         ctx = f"targets[{i}]"
@@ -90,11 +90,14 @@ def validate(data: dict) -> None:
                 f"(optionally with hyphens), got {quant!r}"
             )
 
-        # Rule 7: target ids must be unique
+        # Rule 7: each (id, quant) pair must be unique. The same model id may
+        # appear multiple times with different quants (e.g. a benchmark that
+        # compares quantization schemes); tarball/artifact names already key on
+        # (id_safe, quant), so this is the natural uniqueness boundary.
         tid = target["id"]
-        if tid in seen_ids:
-            _fail(f"duplicate target id '{tid}'")
-        seen_ids.add(tid)
+        if (tid, quant) in seen_id_quants:
+            _fail(f"duplicate target id '{tid}' with quant '{quant}'")
+        seen_id_quants.add((tid, quant))
 
         # Rule 8: no per-target 'onnxruntime' key
         if "onnxruntime" in target:

--- a/tests/test_ci_contracts.py
+++ b/tests/test_ci_contracts.py
@@ -11,6 +11,12 @@ DOCKERFILE = ROOT / "docker" / "lambda-build.Dockerfile"
 
 RELEASE_MANIFEST = ROOT / "builds" / "release.yaml"
 
+BENCH_WORKFLOW = ROOT / ".github" / "workflows" / "benchmark.yml"
+BENCH_C = ROOT / "scripts" / "bench.c"
+RUN_BENCH = ROOT / "scripts" / "run_benchmark.py"
+RENDER_REPORT = ROOT / "scripts" / "render_benchmark_report.py"
+GEN_VECTORS = ROOT / "scripts" / "gen_reference_vectors.py"
+
 
 def test_build_script_uses_fixed_ort_conversion() -> None:
     """CI must convert optimized ONNX to a single fixed ORT artifact."""
@@ -179,3 +185,69 @@ def test_build_script_passes_correctness_defaults() -> None:
 def test_build_script_links_libm_for_smoke_test() -> None:
     text = BUILD_SCRIPT.read_text(encoding="utf-8")
     assert "-lm" in text
+
+
+# ---------------------------------------------------------------------------
+# Benchmark workflow contracts (issue #23)
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_workflow_is_dispatch_only_on_native_arm() -> None:
+    """The benchmark workflow must be manual and run on the native ARM64 runner."""
+    text = BENCH_WORKFLOW.read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in text
+    assert "push:" not in text
+    assert "runs-on: ubuntu-24.04-arm" in text
+
+
+def test_benchmark_workflow_pins_node24_ready_major_action_versions() -> None:
+    text = BENCH_WORKFLOW.read_text(encoding="utf-8")
+    assert "actions/checkout@v6" in text
+    assert "actions/setup-python@v6" in text
+    assert "actions/upload-artifact@v7" in text
+    assert "actions/download-artifact@v7" in text
+
+
+def test_benchmark_workflow_mounts_fixtures_dir() -> None:
+    text = BENCH_WORKFLOW.read_text(encoding="utf-8")
+    assert "tests/data:/fixtures:ro" in text
+    assert "FIXTURE_DIR=/fixtures" in text
+
+
+def test_benchmark_workflow_runs_orchestrator_and_report() -> None:
+    text = BENCH_WORKFLOW.read_text(encoding="utf-8")
+    assert "/scripts/run_benchmark.py" in text
+    assert "render_benchmark_report.py" in text
+
+
+def test_bench_c_disables_runtime_graph_optimization() -> None:
+    text = BENCH_C.read_text(encoding="utf-8")
+    assert "ORT_DISABLE_ALL" in text
+
+
+def test_bench_c_reads_tvb1_format() -> None:
+    text = BENCH_C.read_text(encoding="utf-8")
+    assert "TVB1" in text
+
+
+def test_bench_c_pins_single_thread_batch_one() -> None:
+    """Latency must be measured single-threaded (Lambda profile)."""
+    text = BENCH_C.read_text(encoding="utf-8")
+    assert "SetIntraOpNumThreads" in text
+    assert "SetInterOpNumThreads" in text
+
+
+def test_run_benchmark_links_libm() -> None:
+    text = RUN_BENCH.read_text(encoding="utf-8")
+    assert "-lm" in text
+
+
+def test_render_report_emits_summary_and_results_json() -> None:
+    text = RENDER_REPORT.read_text(encoding="utf-8")
+    assert "GITHUB_STEP_SUMMARY" in text
+    assert "results.json" in text
+
+
+def test_gen_reference_vectors_supports_inputs_only() -> None:
+    text = GEN_VECTORS.read_text(encoding="utf-8")
+    assert "--inputs-only" in text

--- a/tests/test_gen_reference_vectors.py
+++ b/tests/test_gen_reference_vectors.py
@@ -129,3 +129,66 @@ def test_main_writes_vectors_file(monkeypatch, tmp_path):
     # ids [1,2,3,4] truncated to 3 -> output (1,3,2) -> 6 floats
     assert r[0]["reference"].size == 6
     assert r[0]["inputs"]["input_ids"].tolist() == [[1, 2, 3]]
+
+
+def test_main_inputs_only_writes_empty_reference(monkeypatch, tmp_path):
+    module = _load_module()
+
+    class FakeEnc:
+        def __init__(self, ids):
+            self.ids = ids
+
+    class FakeTokenizer:
+        @classmethod
+        def from_file(cls, path):
+            return cls()
+
+        def encode(self, text):
+            return FakeEnc([1, 2, 3, 4])
+
+    fake_tok_mod = types.ModuleType("tokenizers")
+    fake_tok_mod.Tokenizer = FakeTokenizer
+    monkeypatch.setitem(sys.modules, "tokenizers", fake_tok_mod)
+
+    class FakeIO:
+        def __init__(self, name):
+            self.name = name
+
+    class FakeSession:
+        def get_inputs(self):
+            return [FakeIO("input_ids"), FakeIO("attention_mask")]
+
+        def get_outputs(self):
+            return [FakeIO("last_hidden_state")]
+
+        def run(self, output_names, feeds):
+            # --inputs-only must never invoke the reference computation.
+            raise AssertionError("session.run must not be called with --inputs-only")
+
+    fake_ort = types.ModuleType("onnxruntime")
+    fake_ort.InferenceSession = lambda *a, **k: FakeSession()
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+    fixture = tmp_path / "f.jsonl"
+    fixture.write_text('{"text":"hello world"}\n{"text":"second"}\n', encoding="utf-8")
+    tokenizer = tmp_path / "tokenizer.json"
+    tokenizer.write_text("{}", encoding="utf-8")
+    model = tmp_path / "model.ort"
+    model.write_bytes(b"x")
+    out = tmp_path / "v.tvbin"
+
+    module.main([
+        "--inputs-only",
+        "--model", str(model),
+        "--tokenizer", str(tokenizer),
+        "--fixture", str(fixture),
+        "--output", str(out),
+        "--num-samples", "2",
+        "--max-tokens", "3",
+    ])
+
+    r = module.read_vectors(str(out))
+    assert len(r) == 2
+    # Feeds are still present, but the reference payload is empty (ref_count=0).
+    assert r[0]["inputs"]["input_ids"].tolist() == [[1, 2, 3]]
+    assert r[0]["reference"].size == 0

--- a/tests/test_validate_manifest.py
+++ b/tests/test_validate_manifest.py
@@ -89,6 +89,40 @@ def test_duplicate_ids_fail():
     assert "duplicate" in result.stderr.lower()
 
 
+def test_same_id_different_quant_is_valid():
+    """The same model id may appear with different quants (uniqueness is on
+    (id, quant), enabling quant-comparison manifests)."""
+    manifest = textwrap.dedent("""\
+        onnxruntime:
+          version: "1.26.0"
+        build:
+          container_image: public.ecr.aws/lambda/provided:al2023
+          target_os: linux
+          target_arch: arm64
+          cpu_tuning: neoverse-n1
+          execution_provider: cpu
+          minimal_build: extended
+        targets:
+          - id: model-a
+            quant: q4f16
+            model:
+              repo_id: org/repo
+              revision: main
+              primary: onnx/model_q4f16.onnx
+              companions: []
+          - id: model-a
+            quant: fp16
+            model:
+              repo_id: org/repo
+              revision: main
+              primary: onnx/model_fp16.onnx
+              companions: []
+    """)
+    result = _run(stdin_text=manifest)
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+    assert "OK" in result.stdout
+
+
 def test_primary_in_companions_fails():
     manifest = textwrap.dedent("""\
         onnxruntime:


### PR DESCRIPTION
Closes #23.

Adds a standalone, `workflow_dispatch`-only workflow that measures inference performance across the targets/quants in `builds/release.yaml` and renders a side-by-side comparison report. Reuses the existing manifest → matrix → Docker → `.tvbin` → C-harness machinery so the benchmark stays faithful to what actually ships.

## New files
- **`scripts/bench.c`** — C harness reusing `smoke_test.c`'s session setup + TVB1 reader. Single-threaded batch=1 (`ORT_DISABLE_ALL`, `SetIntraOpNumThreads(1)`/`SetInterOpNumThreads(1)`); times `CreateSession` (`load_ms`) and a warmup + timed `Run()` loop; computes p50/p90/p99/mean, throughput, and peak RSS (`getrusage`). Reads and **ignores** the reference payload.
- **`scripts/run_benchmark.py`** — per-target orchestrator (runs in the AL2023 container). `SOURCE=build` runs `build_target.sh`; `SOURCE=release` uses the tarball the workflow pre-downloaded on the runner. Extracts, reads `build-info.json`, sparse-clones ORT headers at the tag, generates `.tvbin` via `--inputs-only`, compiles + runs `bench.c`, merges metrics + artifact sizes → `bench-<id_safe>_<quant>.json`.
- **`scripts/render_benchmark_report.py`** — globs `bench-*.json` → 13-column Markdown table sorted by `(target_id, quant)`; writes `report.md` + `results.json`; appends to `$GITHUB_STEP_SUMMARY`.
- **`.github/workflows/benchmark.yml`** — `plan` → `benchmark` (matrix on `ubuntu-24.04-arm`, runner-side `gh release download` for the release path) → `report`. Actions pinned to Node-24 majors.

## Changed
- **`gen_reference_vectors.py`** — new `--inputs-only` flag: skips the reference `Run()`, writes an empty reference payload (`ref_count=0`); still reads model input names so feeds match.
- **`validate_manifest.py`** — uniqueness keyed on `(id, quant)` instead of `id`, matching how tarballs/artifacts are already named.
- **`builds/release.yaml`** — added `fp16` + `q4` quants of the Jina nano model for a 3-row comparison.
- **tests** — benchmark CI-contract guards, `(id, quant)` uniqueness, `--inputs-only`.

## Design decisions (confirmed during planning)
- **Release download on the runner** (`gh` preinstalled), mounted read-only into the container — no Dockerfile change; `run_benchmark.py` never calls `gh`.
- **Uniqueness relaxed to `(id, quant)`** to enable same-model multi-quant comparison rows.

## Heads-up
Because `build.yml` shares `release.yaml`, tagged releases will now also build & publish the `fp16` and `q4` quants (≈3× build time). Easy to scope those to benchmarking only if preferred.

## Verification
- `python3 scripts/validate_manifest.py builds/release.yaml` → OK; matrix emits 3 distinct targets.
- `pytest tests/` → **94 passed**.
- Report renderer dry-run: correct sorted 13-column table, `results.json`, and `$GITHUB_STEP_SUMMARY` match.
- `bench.c` compiles only in CI (Linux `getrusage`/`clock_gettime` + ORT header from the clone), same as `smoke_test.c`.

Full end-to-end runs via `workflow_dispatch` (`source=build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)